### PR TITLE
Error en Fixtures-Usuario-Direccion

### DIFF
--- a/src/Cupon/UsuarioBundle/DataFixtures/ORM/Usuarios.php
+++ b/src/Cupon/UsuarioBundle/DataFixtures/ORM/Usuarios.php
@@ -59,7 +59,7 @@ class Usuarios extends AbstractFixture implements OrderedFixtureInterface, Conta
             $passwordCodificado = $encoder->encodePassword($passwordEnClaro, $usuario->getSalt());
             $usuario->setPassword($passwordCodificado);
             
-            $usuario->setDireccion('Gran Vía, '.rand(), 1, 250);
+            $usuario->setDireccion('Gran Vía, '.rand(1, 250));
             // El 60% de los usuarios permite email
             $usuario->setPermiteEmail((rand(1, 1000) % 10) < 6);
             $usuario->setFechaAlta(new \DateTime('now - '.rand(1, 150).' days'));


### PR DESCRIPTION
Corregido un error en las Fixtures de Usuario, al generar el número de la calle del campo dirección
