### PR TITLE
deps>DoctrineFixturesBundle error

### DIFF
--- a/deps
+++ b/deps
@@ -68,8 +68,9 @@
     git=http://github.com/doctrine/data-fixtures.git
 
 [DoctrineFixturesBundle]
-    git=http://github.com/symfony/DoctrineFixturesBundle.git
+    git=http://github.com/doctrine/DoctrineFixturesBundle.git
     target=/bundles/Symfony/Bundle/DoctrineFixturesBundle
+    version=origin/2.0
 
 [doctrine-extensions]
     git=https://github.com/beberlei/DoctrineExtensions.git


### PR DESCRIPTION
deps>DoctrineFixturesBundle cambiado de github.com/symfony a github.com/doctrine
