### PR TITLE
Corrección src/AppBundle/Controller/DefaultController.php

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -39,7 +39,7 @@ class DefaultController extends Controller
     }
 
     /**
-     * @Route("/contacto", defaults={ "_locale"="es" }, name="contacto")
+     * @Route("/sitio/contacto", defaults={ "_locale"="es" }, name="contacto")
      *
      * Muestra el formulario de contacto y también procesa el envío de emails.
      *


### PR DESCRIPTION
#174 
La ruta de contactoAction contiene un error que provoca error 500 al pulsar en el link "Contacto" al pìé de las páginas.

Línea 42 de src/AppBundle/Controller/DefaultController.php debe contener:
     * @Route("/**sitio/**contacto", defaults={ "_locale"="es" }, name="contacto")